### PR TITLE
Forbid the use of urllib.request in scraper.py

### DIFF
--- a/crawler/worker.py
+++ b/crawler/worker.py
@@ -13,7 +13,8 @@ class Worker(Thread):
         self.config = config
         self.frontier = frontier
         # basic check for requests in scraper
-        assert {getsource(scraper).find(req) for req in {"from requests import", "import requests"}} == {-1}, "Do not use requests from scraper.py"
+        assert {getsource(scraper).find(req) for req in {"from requests import", "import requests"}} == {-1}, "Do not use requests in scraper.py"
+        assert {getsource(scraper).find(req) for req in {"from urllib.request import", "import urllib.request"}} == {-1}, "Do not use urllib.request in scraper.py"
         super().__init__(daemon=True)
         
     def run(self):


### PR DESCRIPTION
Students only understand rules when they are enforced. Sigh.